### PR TITLE
Prevent CocoaPods auto-upgrading PMK to 2.0

### DIFF
--- a/Parse+PromiseKit.podspec
+++ b/Parse+PromiseKit.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.subspec 'Base' do |bs|
     bs.source_files = 'PMKPFMacros.h'
 
-    bs.dependency 'PromiseKit/base'
+    bs.dependency 'PromiseKit/base', '~> 1.5'
 
     bs.frameworks = 'Foundation'
   end


### PR DESCRIPTION
PromiseKit 2 is almost ready, let’s not have your users get auto-upgraded before you have verified that everything still works.

Everything _should_ still work. This is just a sensible precaution.
